### PR TITLE
Update twitter list version in the Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/everypolitician/twitter_list
-  revision: 25087ee3d4b97a0bfeac37d9c915d018d1ce453b
+  revision: 06ec0b4521a964674ba482dfa3efc0dc43c1a1e0
   specs:
-    twitter_list (0.0.1)
+    twitter_list (0.0.2)
       twitter
 
 GIT


### PR DESCRIPTION
Even though the Twitter List gem was updated yesterday, the scrapers were still failing on morph.io, due to the Gemfile.lock still pointing at the first version of the gem (0.0.1). This PR updates the `Gemfile.lock` file by running

``` bash
$ bundle update twitter_list
```
